### PR TITLE
Signal error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,8 +56,6 @@ func NewClient(addr string, cfg WebRTCTransportConfig) *Client {
 		notify:         make(chan struct{}),
 		remoteStreamId: make(map[string]string),
 	}
-	c.pub = NewTransport(PUBLISHER, c.signal, c.cfg)
-	c.sub = NewTransport(SUBSCRIBER, c.signal, c.cfg)
 
 	c.signal.OnNegotiate = c.Negotiate
 	c.signal.OnTrickle = c.Trickle
@@ -67,6 +65,9 @@ func NewClient(addr string, cfg WebRTCTransportConfig) *Client {
 			c.OnError(err)
 		}
 	}
+
+	c.pub = NewTransport(PUBLISHER, c.signal, c.cfg)
+	c.sub = NewTransport(SUBSCRIBER, c.signal, c.cfg)
 
 	// this will be called when pub add/remove/replace track, but pion never triger, why?
 	// c.pub.pc.OnNegotiationNeeded(c.OnNegotiationNeeded)

--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	//export to user
 	OnTrack       func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver)
 	OnDataChannel func(*webrtc.DataChannel)
+	OnError       func(error)
 
 	producer *WebMProducer
 	recvByte int
@@ -61,6 +62,11 @@ func NewClient(addr string, cfg WebRTCTransportConfig) *Client {
 	c.signal.OnNegotiate = c.Negotiate
 	c.signal.OnTrickle = c.Trickle
 	c.signal.OnSetRemoteSDP = c.SetRemoteSDP
+	c.signal.OnError = func(err error) {
+		if c.OnError != nil {
+			c.OnError(err)
+		}
+	}
 
 	// this will be called when pub add/remove/replace track, but pion never triger, why?
 	// c.pub.pc.OnNegotiationNeeded(c.OnNegotiationNeeded)


### PR DESCRIPTION
#### Description
Provides a mechanism to handle signalling errors similar to the JavaScript SDK.

Adds an `OnError` callback to `Signal` and `Client` which propagates errors from the signal stream client to the user.  Also changes `Signal.onSignalHandle` to be started on first use of the signalling client rather than in the constructor to avoid a race condition between the when `OnError` is registered and when the read loop can call it.

An alternative to the `once` starting the read loop would have been an explicit `Start` method which would needed to be called in the `Client`, however I favoured this as didn't change the `Signal` interface.
