### PR TITLE
Fix PublishWebm call in example

### DIFF
--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	// publish file to session if needed
 	if err == nil && file != "" {
-		err = c.PublishWebm(file)
+		err = c.PublishWebm(file, true, true)
 		if err != nil {
 			log.Errorf("err=%v", err)
 		}


### PR DESCRIPTION
The call of PublishWebm changed and now needs two extra parameters - for saving audio & video tracks. Add them for simple example to build and work.


