### PR TITLE
Update g_memdup call to g_memdup2

### DIFF
--- a/pkg/gstreamer-sink/gst.c
+++ b/pkg/gstreamer-sink/gst.c
@@ -54,7 +54,7 @@ void gstreamer_receive_stop_pipeline(GstElement *pipeline) { gst_element_set_sta
 void gstreamer_receive_push_buffer(GstElement *pipeline, void *buffer, int len) {
   GstElement *src = gst_bin_get_by_name(GST_BIN(pipeline), "src");
   if (src != NULL) {
-    gpointer p = g_memdup(buffer, len);
+    gpointer p = g_memdup2(buffer, len);
     GstBuffer *buffer = gst_buffer_new_wrapped(p, len);
     gst_app_src_push_buffer(GST_APP_SRC(src), buffer);
     gst_object_unref(src);


### PR DESCRIPTION
Fixes this warning:
```
# github.com/pion/ion-sdk-go/pkg/gstreamer-sink
gst.c:57:18: warning: 'g_memdup' is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
/usr/local/Cellar/glib/2.70.1/include/glib-2.0/glib/gstrfuncs.h:256:1: note: 'g_memdup' has been explicitly marked deprecated here
/usr/local/Cellar/glib/2.70.1/include/glib-2.0/glib/gversionmacros.h:1057:49: note: expanded from macro 'GLIB_DEPRECATED_IN_2_68_FOR'
/usr/local/Cellar/glib/2.70.1/include/glib-2.0/glib/gmacros.h:1144:32: note: expanded from macro 'GLIB_DEPRECATED_FOR'
/usr/local/Cellar/glib/2.70.1/include/glib-2.0/glib/gmacros.h:1112:44: note: expanded from macro 'G_DEPRECATED_FOR'
```
