### PR TITLE
add outgoing metadata to requests

### DIFF
--- a/room.go
+++ b/room.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/metadata"
 	"io"
 	"sync"
 
@@ -572,6 +573,7 @@ func (c *Room) Name() string {
 func (c *Room) Connect() {
 	var err error
 	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.ctx = metadata.NewOutgoingContext(c.ctx, c.connector.Metadata)
 	c.roomServiceClient = room.NewRoomServiceClient(c.connector.grpcConn)
 	c.roomSignalClient = room.NewRoomSignalClient(c.connector.grpcConn)
 	c.roomSignalStream, err = c.roomSignalClient.Signal(c.ctx)

--- a/rtc.go
+++ b/rtc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"google.golang.org/grpc/metadata"
 	"io"
 	"os"
 	"path/filepath"
@@ -284,8 +285,8 @@ func (r *RTC) Publish(tracks ...webrtc.TrackLocal) ([]*webrtc.RTPSender, error) 
 		if rtpSender, err := r.pub.GetPeerConnection().AddTrack(t); err != nil {
 			log.Errorf("AddTrack error: %v", err)
 			return rtpSenders, err
-		}else{
-			rtpSenders=append(rtpSenders,rtpSender)
+		} else {
+			rtpSenders = append(rtpSenders, rtpSender)
 		}
 
 	}
@@ -303,7 +304,6 @@ func (r *RTC) UnPublish(senders ...*webrtc.RTPSender) error {
 	r.onNegotiationNeeded()
 	return nil
 }
-
 
 // CreateDataChannel create a custom datachannel
 func (r *RTC) CreateDataChannel(label string) (*webrtc.DataChannel, error) {
@@ -559,6 +559,7 @@ func (r *RTC) Connect() {
 	var err error
 
 	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.ctx = metadata.NewOutgoingContext(r.ctx, r.connector.Metadata)
 	r.client = rtc.NewRTCClient(r.connector.grpcConn)
 	r.stream, err = r.client.Signal(r.ctx)
 


### PR DESCRIPTION
#### Description

Outgoing requests were not using the metadata configured on the Connector. This adds it

#### Reference issue
Fixes #...
