### PR TITLE
abstract GRPC implementation so alternative signalling methods are possible

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"github.com/pion/ion/proto/rtc"
 	"io/ioutil"
 
 	log "github.com/pion/ion-log"
@@ -104,6 +105,13 @@ func NewConnector(addr string, config ...ConnectorConfig) *Connector {
 	log.Infof("gRPC connected: %s", addr)
 
 	return c
+}
+
+func (c *Connector) Signal(r *RTC) (Signaller, error) {
+	c.RegisterService(r)
+	client := rtc.NewRTCClient(c.grpcConn)
+	r.ctx = metadata.NewOutgoingContext(r.ctx, c.Metadata)
+	return client.Signal(r.ctx)
 }
 
 func (c *Connector) Close() {

--- a/example/ion-cluster-simple/main.go
+++ b/example/ion-cluster-simple/main.go
@@ -101,7 +101,13 @@ func main() {
 	// ===============================
 	room.OnJoin = func(success bool, info sdk.RoomInfo, err error) {
 		log.Infof("OnJoin success = %v, info = %v, err = %v", success, info, err)
-		rtc := sdk.NewRTC(connector)
+		rtc := sdk.NewRTC()
+		signaller, err := connector.Signal(rtc)
+		if err != nil {
+			log.Fatalf("failed to create grpc signaller, err: %v", err)
+		}
+		rtc.Start(signaller)
+
 		// subscribe rtp from sessoin
 		// comment this if you don't need save to file
 		rtc.OnTrack = func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {

--- a/example/ion-cluster-simple/main.go
+++ b/example/ion-cluster-simple/main.go
@@ -101,12 +101,10 @@ func main() {
 	// ===============================
 	room.OnJoin = func(success bool, info sdk.RoomInfo, err error) {
 		log.Infof("OnJoin success = %v, info = %v, err = %v", success, info, err)
-		rtc := sdk.NewRTC()
-		signaller, err := connector.Signal(rtc)
+		rtc, err := sdk.NewRTC(connector)
 		if err != nil {
-			log.Fatalf("failed to create grpc signaller, err: %v", err)
+			log.Fatal(err)
 		}
-		rtc.Start(signaller)
 
 		// subscribe rtp from sessoin
 		// comment this if you don't need save to file

--- a/example/ion-sfu-gstreamer-receive/main.go
+++ b/example/ion-sfu-gstreamer-receive/main.go
@@ -29,7 +29,10 @@ func runClientLoop(addr, session string) {
 	// new sdk engine
 	connector := sdk.NewConnector(addr)
 
-	rtc := sdk.NewRTC(connector)
+	rtc, err := sdk.NewRTC(connector)
+	if err != nil {
+		panic(err)
+	}
 
 	// subscribe rtp from sessoin
 	// comment this if you don't need save to file
@@ -70,7 +73,7 @@ func runClientLoop(addr, session string) {
 	}
 
 	// client join a session
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	// publish file to session if needed
 	if err != nil {

--- a/example/ion-sfu-gstreamer-send/main.go
+++ b/example/ion-sfu-gstreamer-send/main.go
@@ -32,7 +32,10 @@ func main() {
 	}
 
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector, config)
+	rtc, err := sdk.NewRTC(connector, config)
+	if err != nil {
+		panic(err)
+	}
 
 	videoTrack, err := webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{MimeType: "video/vp8"}, "video", "pion2")
 	if err != nil {

--- a/example/ion-sfu-join-from-mediadevice/main.go
+++ b/example/ion-sfu-join-from-mediadevice/main.go
@@ -33,12 +33,16 @@ func main() {
 	flag.Parse()
 
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	rtc, err := sdk.NewRTC(connector)
+	if err != nil {
+		panic(err)
+	}
+
 	rtc.GetPubTransport().GetPeerConnection().OnICEConnectionStateChange(func(state webrtc.ICEConnectionState) {
 		log.Infof("Connection state changed: %s", state)
 	})
 
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	if err != nil {
 		log.Errorf("join err=%v", err)

--- a/example/ion-sfu-load-tool/main.go
+++ b/example/ion-sfu-load-tool/main.go
@@ -58,20 +58,26 @@ func NewEngine(addr string) *Engine {
 	return e
 }
 
-func (e *Engine) AddClient(sid, cid string) *sdk.RTC {
+func (e *Engine) AddClient(sid, cid string) (*sdk.RTC, error) {
 	e.Lock()
 	defer e.Unlock()
 	if e.clients[sid] == nil {
 		e.clients[sid] = make(map[string]*sdk.RTC)
 	}
 
-	c := sdk.NewRTC(e.connector)
+	c := sdk.NewRTC()
+	signaller, err := e.connector.Signal(c)
+	if err != nil {
+		return nil, err
+	}
+	c.Start(signaller)
+
 	e.clients[sid][cid] = c
 	c.OnError = func(err error) {
 		log.Errorf("engine got error: %v", err)
 		e.DelClient(sid, cid)
 	}
-	return c
+	return c, nil
 }
 
 func (e *Engine) DelClient(sid, cid string) {
@@ -149,8 +155,12 @@ func run(e *Engine, addr, session, file, role string, total, duration, cycle int
 		case "pubsub":
 			cid := fmt.Sprintf("%s_pubsub_%d_%s", session, i, cuid.New())
 			log.Infof("AddClient session=%v clientid=%v", session, cid)
-			c := e.AddClient(session, cid)
-			err := c.Join(session, cid)
+			c, err := e.AddClient(session, cid)
+			if err != nil {
+				log.Errorf("error: %v", err)
+				break
+			}
+			err = c.Join(session, cid)
 			if err != nil {
 				log.Errorf("error: %v", err)
 				break
@@ -164,14 +174,18 @@ func run(e *Engine, addr, session, file, role string, total, duration, cycle int
 		case "sub":
 			cid := fmt.Sprintf("%s_sub_%d_%s", session, i, cuid.New())
 			log.Infof("AddClient session=%v clientid=%v", session, cid)
-			c := e.AddClient(session, cid)
+			c, err := e.AddClient(session, cid)
+			if err != nil {
+				log.Errorf("%v", err)
+				break
+			}
 
 			c.OnTrackEvent = func(event sdk.TrackEvent) {
 				_ = c.SubscribeFromEvent(event, audio, video, simulcast)
 			}
 
 			config := sdk.NewJoinConfig().SetNoAutoSubscribe()
-			err := c.Join(session, cid, config)
+			err = c.Join(session, cid, config)
 
 			if err != nil {
 				log.Errorf("%v", err)
@@ -181,8 +195,13 @@ func run(e *Engine, addr, session, file, role string, total, duration, cycle int
 		case "pub":
 			cid := fmt.Sprintf("%s_pub_%d_%s", session, i, cuid.New())
 			log.Infof("AddClient session=%v clientid=%v", session, cid)
-			c := e.AddClient(session, cid)
-			err := c.Join(session, cid)
+			c, err := e.AddClient(session, cid)
+			if err != nil {
+				log.Errorf("%v", err)
+				break
+			}
+
+			err = c.Join(session, cid)
 			if err != nil {
 				log.Errorf("%v", err)
 				break

--- a/example/ion-sfu-load-tool/main.go
+++ b/example/ion-sfu-load-tool/main.go
@@ -65,12 +65,10 @@ func (e *Engine) AddClient(sid, cid string) (*sdk.RTC, error) {
 		e.clients[sid] = make(map[string]*sdk.RTC)
 	}
 
-	c := sdk.NewRTC()
-	signaller, err := e.connector.Signal(c)
+	c, err := sdk.NewRTC(e.connector)
 	if err != nil {
 		return nil, err
 	}
-	c.Start(signaller)
 
 	e.clients[sid][cid] = c
 	c.OnError = func(err error) {

--- a/example/ion-sfu-save-to-disk/main.go
+++ b/example/ion-sfu-save-to-disk/main.go
@@ -27,13 +27,11 @@ func main() {
 	flag.StringVar(&session, "session", "ion", "join session name")
 	flag.Parse()
 
-	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	signaller, err := connector.Signal(rtc)
+	rtc, err := sdk.NewRTC(connector)
 	if err != nil {
 		panic(err)
 	}
-	rtc.Start(signaller)
 
 	rtc.OnTrack = func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
 		fmt.Println("Got track")

--- a/example/ion-sfu-save-to-disk/main.go
+++ b/example/ion-sfu-save-to-disk/main.go
@@ -27,8 +27,13 @@ func main() {
 	flag.StringVar(&session, "session", "ion", "join session name")
 	flag.Parse()
 
+	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	signaller, err := connector.Signal(rtc)
+	if err != nil {
+		panic(err)
+	}
+	rtc.Start(signaller)
 
 	rtc.OnTrack = func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
 		fmt.Println("Got track")
@@ -74,7 +79,7 @@ func main() {
 				log.Debugf("Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)")
 
 				if err := oggFile.WriteRTP(rtpPacket); err != nil {
-					log.Panicf("Error write ogg: ", err)
+					log.Panicf("Error write ogg: %v", err)
 				}
 			} else if codecName == "vp8" {
 				log.Debugf("Got VP8 track, saving to disk as output.ivf")
@@ -85,7 +90,7 @@ func main() {
 				}
 
 				if err := ivfFile.WriteRTP(rtpPacket); err != nil {
-					log.Panicf("Error write ivf: ", err)
+					log.Panicf("Error write ivf: %v", err)
 				}
 			}
 
@@ -93,7 +98,7 @@ func main() {
 	}
 
 	// client join a session
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	// publish file to session if needed
 	if err != nil {

--- a/example/ion-sfu-save-to-mkv/README.md
+++ b/example/ion-sfu-save-to-mkv/README.md
@@ -1,0 +1,17 @@
+# Save to mkv
+
+This example will take an audio and video track and save it into a local file.
+
+## Quick Start
+
+1. Start ion-sfu allrpc, and run [pubsubtest example](https://github.com/pion/ion-sfu/tree/master/examples/pubsubtest) in your browser and you join with your web camera to add an audio/video track to the "test session" room.
+
+2. select h264
+
+3. Run the script
+
+```
+go run main.go -addr "localhost:5551" -session "ion"
+```
+
+3. Your video or audio track will be saved and can be accessed after quitting the application with `Control + C`

--- a/example/ion-sfu-save-to-mkv/main.go
+++ b/example/ion-sfu-save-to-mkv/main.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"github.com/at-wat/ebml-go/mkvcore"
+	"github.com/at-wat/ebml-go/webm"
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+	"io"
+	"math"
+	"os"
+	"os/signal"
+	"time"
+
+	log "github.com/pion/ion-log"
+	sdk "github.com/pion/ion-sdk-go"
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media/samplebuilder"
+)
+
+type mkvSaver struct {
+	audioWriter, videoWriter       webm.BlockWriteCloser
+	audioBuilder, videoBuilder     *samplebuilder.SampleBuilder
+	audioTimestamp, videoTimestamp time.Duration
+}
+
+func newMkvSaver() *mkvSaver {
+	return &mkvSaver{
+		audioBuilder: samplebuilder.New(32, &codecs.OpusPacket{}, 48000),
+		videoBuilder: samplebuilder.New(1024, &codecs.H264Packet{}, 90000),
+	}
+}
+
+func (s *mkvSaver) Close() {
+	fmt.Printf("Finalizing mkv...\n")
+	if s.audioWriter != nil {
+		if err := s.audioWriter.Close(); err != nil {
+			panic(err)
+		}
+	}
+	if s.videoWriter != nil {
+		if err := s.videoWriter.Close(); err != nil {
+			panic(err)
+		}
+	}
+}
+func (s *mkvSaver) PushOpus(rtpPacket *rtp.Packet) {
+	s.audioBuilder.Push(rtpPacket)
+
+	for {
+		sample := s.audioBuilder.Pop()
+		if sample == nil {
+			return
+		}
+		if s.audioWriter != nil {
+			s.audioTimestamp += sample.Duration
+			if _, err := s.audioWriter.Write(true, int64(s.videoTimestamp/time.Millisecond), sample.Data); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+func (s *mkvSaver) Push264(rtpPacket *rtp.Packet) {
+	s.videoBuilder.Push(rtpPacket)
+
+	for {
+		sample := s.videoBuilder.Pop()
+		if sample == nil {
+			return
+		}
+		naluType := sample.Data[4] & 0x1F
+		videoKeyframe := (naluType == 7) || (naluType == 8)
+		if videoKeyframe {
+			if (s.videoWriter == nil || s.audioWriter == nil) && naluType == 7 {
+				p := bytes.SplitN(sample.Data[4:], []byte{0x00, 0x00, 0x00, 0x01}, 2)
+				if width, height, fps, ok := H264_decode_sps(p[0], uint(len(p[0]))); ok {
+					log.Errorf("width:%d, height:%d, fps:%d", width, height, fps)
+					s.InitWriter(width, height)
+				}
+			}
+		}
+		if s.videoWriter != nil {
+			s.videoTimestamp += sample.Duration
+			if _, err := s.videoWriter.Write(videoKeyframe, int64(s.videoTimestamp/time.Millisecond), sample.Data); err != nil {
+				panic(err)
+			}
+		}
+
+	}
+}
+func (s *mkvSaver) InitWriter(width, height int) {
+	w, err := os.OpenFile("test.mkv", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		panic(err)
+	}
+	var desc []mkvcore.TrackDescription
+	desc = append(desc,
+		mkvcore.TrackDescription{
+			TrackNumber: uint64(1),
+			TrackEntry: webm.TrackEntry{
+				Name:        "Audio",
+				TrackNumber: 1,
+				CodecID:     "A_OPUS",
+				TrackType:   2,
+				Audio: &webm.Audio{
+					SamplingFrequency: 48000.0,
+					Channels:          2,
+				},
+			},
+		},
+	)
+
+	desc = append(desc,
+		mkvcore.TrackDescription{
+			TrackNumber: uint64(2),
+			TrackEntry: webm.TrackEntry{
+				Name:        "Video",
+				TrackNumber: 2,
+				CodecID:     "V_MPEG4/ISO/AVC",
+				TrackType:   1,
+				Video: &webm.Video{
+					PixelWidth:  uint64(width),
+					PixelHeight: uint64(height),
+				},
+			},
+		},
+	)
+	header := webm.DefaultEBMLHeader
+	header.DocType = "matroska"
+	ws, err := mkvcore.NewSimpleBlockWriter(
+		w, desc,
+		mkvcore.WithEBMLHeader(header),
+		mkvcore.WithSegmentInfo(webm.DefaultSegmentInfo),
+		mkvcore.WithBlockInterceptor(webm.DefaultBlockInterceptor),
+	)
+
+	s.audioWriter = ws[0]
+	s.videoWriter = ws[1]
+}
+
+func main() {
+	// parse flag
+	var session, addr string
+	flag.StringVar(&addr, "addr", "localhost:5551", "ion-sfu grpc addr")
+	flag.StringVar(&session, "session", "ion", "join session name")
+	flag.Parse()
+
+	connector := sdk.NewConnector(addr)
+	rtc := sdk.NewRTC(connector)
+	saver := newMkvSaver()
+	defer saver.Close()
+
+	rtc.OnTrack = func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
+		if track.Kind() == webrtc.RTPCodecTypeVideo {
+			go func() {
+				ticker := time.NewTicker(time.Second * 3)
+				for range ticker.C {
+					rtcpSendErr := rtc.GetSubTransport().GetPeerConnection().WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}})
+					if rtcpSendErr != nil {
+						fmt.Println(rtcpSendErr)
+					}
+				}
+			}()
+		}
+
+		fmt.Printf("Track has started, of type %d: %s \n", track.PayloadType(), track.Codec().RTPCodecCapability.MimeType)
+		for {
+			// Read RTP packets being sent to Pion
+			rtp, _, readErr := track.ReadRTP()
+			if readErr != nil {
+				if readErr == io.EOF {
+					return
+				}
+				panic(readErr)
+			}
+			switch track.Kind() {
+			case webrtc.RTPCodecTypeAudio:
+				saver.PushOpus(rtp)
+			case webrtc.RTPCodecTypeVideo:
+				saver.Push264(rtp)
+			}
+		}
+	}
+
+	// client join a session
+	err := rtc.Join(session, sdk.RandomKey(4))
+
+	if err != nil {
+		log.Errorf("error: %v", err)
+	}
+
+	// Close peer connection on exit
+	defer rtc.GetPubTransport().GetPeerConnection().Close()
+
+	closed := make(chan os.Signal, 1)
+	signal.Notify(closed, os.Interrupt)
+	<-closed
+}
+
+//
+func Ue(pBuff []byte, nLen uint, nStartBit *uint) uint {
+	//计算0bit的个数
+	var nZeroNum int = 0
+	for *nStartBit < nLen*8 {
+		if (pBuff[*nStartBit/8] & (0x80 >> (*nStartBit % 8))) > 0 {
+			break
+		}
+		nZeroNum++
+		*nStartBit++
+	}
+	*nStartBit++
+
+	//计算结果
+	var dwRet uint = 0
+	for i := 0; i < nZeroNum; i++ {
+		dwRet <<= 1
+		if (pBuff[*nStartBit/8] & (0x80 >> (*nStartBit % 8))) > 0 {
+			dwRet += 1
+		}
+		*nStartBit++
+	}
+	return (1 << nZeroNum) - 1 + dwRet
+}
+
+func Se(pBuff []byte, nLen uint, nStartBit *uint) int {
+	UeVal := Ue(pBuff, nLen, nStartBit)
+	var k int64 = (int64)(UeVal)
+	var nValue int = (int)(math.Ceil((float64)(k / 2))) //ceil函数：ceil函数的作用是求不小于给定实数的最小整数。ceil(2)=ceil(1.2)=cei(1.5)=2.00
+	if UeVal%2 == 0 {
+		nValue = -nValue
+	}
+	return nValue
+}
+
+func u(BitCount uint, buf []byte, nStartBit *uint) uint {
+	var dwRet uint = 0
+	var i uint = 0
+	for i = 0; i < BitCount; i++ {
+		dwRet <<= 1
+		if (buf[*nStartBit/8] & (0x80 >> (*nStartBit % 8))) > 0 {
+			dwRet += 1
+		}
+		*nStartBit++
+	}
+	return dwRet
+}
+
+func de_emulation_prevention(buf []byte, buf_size *uint) {
+	i := 0
+	j := 0
+	tmp_ptr := make([]byte, len(buf))
+	var tmp_buf_size uint = 0
+	var val int = 0
+
+	tmp_ptr = buf
+	tmp_buf_size = *buf_size
+	for i = 0; i < (int)(tmp_buf_size-2); i++ {
+		//check for 0x000003
+		val = (int)((tmp_ptr[i] ^ 0x00) + (tmp_ptr[i+1] ^ 0x00) + (tmp_ptr[i+2] ^ 0x03))
+		if val == 0 {
+			//kick out 0x03
+			for j = i + 2; j < (int)(tmp_buf_size-1); j++ {
+				tmp_ptr[j] = tmp_ptr[j+1]
+			}
+
+			//and so we should devrease bufsize
+			*buf_size--
+		}
+	}
+}
+
+/**
+ * 解码SPS,获取视频图像宽、高和帧率信息
+ *
+ * @param buf SPS数据内容
+ * @param nLen SPS数据的长度
+ * @param width 图像宽度
+ * @param height 图像高度
+ * @成功则返回true , 失败则返回false
+ */
+func H264_decode_sps(buf []byte, nLen uint) (int, int, uint, bool) {
+	var StartBit uint = 0
+	var fps uint = 0
+	de_emulation_prevention(buf, &nLen)
+
+	u(1, buf, &StartBit) //forbidden_zero_bit :=
+	u(2, buf, &StartBit) //nal_ref_idc :=
+	nal_unit_type := u(5, buf, &StartBit)
+	if nal_unit_type == 7 {
+		profile_idc := u(8, buf, &StartBit) //
+		_ = u(1, buf, &StartBit)            //(buf[1] & 0x80)>>7  constraint_set0_flag
+		_ = u(1, buf, &StartBit)            //(buf[1] & 0x40)>>6;constraint_set1_flag
+		_ = u(1, buf, &StartBit)            //(buf[1] & 0x20)>>5;constraint_set2_flag
+		_ = u(1, buf, &StartBit)            //(buf[1] & 0x10)>>4;constraint_set3_flag
+		_ = u(4, buf, &StartBit)            //reserved_zero_4bits
+		u(8, buf, &StartBit)                //level_idc :=
+
+		Ue(buf, nLen, &StartBit) //seq_parameter_set_id :=
+
+		if profile_idc == 100 || profile_idc == 110 || profile_idc == 122 || profile_idc == 144 {
+			chroma_format_idc := Ue(buf, nLen, &StartBit)
+			if chroma_format_idc == 3 {
+				u(1, buf, &StartBit) //residual_colour_transform_flag :=
+			}
+
+			Ue(buf, nLen, &StartBit) //bit_depth_luma_minus8 :=
+			Ue(buf, nLen, &StartBit) //bit_depth_chroma_minus8 :=
+			u(1, buf, &StartBit)     //qpprime_y_zero_transform_bypass_flag :=
+			seq_scaling_matrix_present_flag := u(1, buf, &StartBit)
+
+			seq_scaling_list_present_flag := make([]int, 8)
+			if seq_scaling_matrix_present_flag > 0 {
+				for i := 0; i < 8; i++ {
+					seq_scaling_list_present_flag[i] = (int)(u(1, buf, &StartBit))
+				}
+			}
+		}
+		Ue(buf, nLen, &StartBit) //log2_max_frame_num_minus4 :=
+		pic_order_cnt_type := Ue(buf, nLen, &StartBit)
+		if pic_order_cnt_type == 0 {
+			Ue(buf, nLen, &StartBit) //log2_max_pic_order_cnt_lsb_minus4 :=
+		} else if pic_order_cnt_type == 1 {
+			u(1, buf, &StartBit)     //delta_pic_order_always_zero_flag :=
+			Se(buf, nLen, &StartBit) //offset_for_non_ref_pic :=
+			Se(buf, nLen, &StartBit) //offset_for_top_to_bottom_field :=
+			num_ref_frames_in_pic_order_cnt_cycle := Ue(buf, nLen, &StartBit)
+
+			offset_for_ref_frame := make([]int, num_ref_frames_in_pic_order_cnt_cycle)
+			for i := 0; i < (int)(num_ref_frames_in_pic_order_cnt_cycle); i++ {
+				offset_for_ref_frame[i] = Se(buf, nLen, &StartBit)
+			}
+		}
+		Ue(buf, nLen, &StartBit) //num_ref_frames :=
+		u(1, buf, &StartBit)     //gaps_in_frame_num_value_allowed_flag :=
+		pic_width_in_mbs_minus1 := Ue(buf, nLen, &StartBit)
+		pic_height_in_map_units_minus1 := Ue(buf, nLen, &StartBit)
+
+		width := (pic_width_in_mbs_minus1 + 1) * 16
+		height := (pic_height_in_map_units_minus1 + 1) * 16
+
+		frame_mbs_only_flag := u(1, buf, &StartBit)
+		if frame_mbs_only_flag <= 0 {
+			u(1, buf, &StartBit) //mb_adaptive_frame_field_flag :=
+		}
+
+		u(1, buf, &StartBit) //direct_8x8_inference_flag :=
+		frame_cropping_flag := u(1, buf, &StartBit)
+		if frame_cropping_flag > 0 {
+			Ue(buf, nLen, &StartBit) //frame_crop_left_offset:=
+			Ue(buf, nLen, &StartBit) //frame_crop_right_offset:=
+			Ue(buf, nLen, &StartBit) //frame_crop_top_offset:=
+			Ue(buf, nLen, &StartBit) //frame_crop_bottom_offset:=
+		}
+		vui_parameter_present_flag := u(1, buf, &StartBit)
+		if vui_parameter_present_flag > 0 {
+			aspect_ratio_info_present_flag := u(1, buf, &StartBit)
+			if aspect_ratio_info_present_flag > 0 {
+				aspect_ratio_idc := u(8, buf, &StartBit)
+				if aspect_ratio_idc == 255 {
+					u(16, buf, &StartBit) //sar_width:=
+					u(16, buf, &StartBit) //sar_height:=
+				}
+			}
+			overscan_info_present_flag := u(1, buf, &StartBit)
+			if overscan_info_present_flag > 0 {
+				u(1, buf, &StartBit) //overscan_appropriate_flagu:=
+			}
+			video_signal_type_present_flag := u(1, buf, &StartBit)
+			if video_signal_type_present_flag > 0 {
+				u(3, buf, &StartBit) //video_format:=
+				u(1, buf, &StartBit) //video_full_range_flag:=
+				colour_description_present_flag := u(1, buf, &StartBit)
+				if colour_description_present_flag > 0 {
+					u(8, buf, &StartBit) //colour_primaries:=
+					u(8, buf, &StartBit) //transfer_characteristics:=
+					u(8, buf, &StartBit) //matrix_coefficients:=
+				}
+			}
+			chroma_loc_info_present_flag := u(1, buf, &StartBit)
+			if chroma_loc_info_present_flag > 0 {
+				Ue(buf, nLen, &StartBit) //chroma_sample_loc_type_top_field:=
+				Ue(buf, nLen, &StartBit) //chroma_sample_loc_type_bottom_field:=
+			}
+			timing_info_present_flag := u(1, buf, &StartBit)
+
+			if timing_info_present_flag > 0 {
+				num_units_in_tick := u(32, buf, &StartBit)
+				time_scale := u(32, buf, &StartBit)
+				fps = time_scale / num_units_in_tick
+				fixed_frame_rate_flag := u(1, buf, &StartBit)
+				if fixed_frame_rate_flag > 0 {
+					fps = fps / 2
+				}
+			}
+		}
+		return int(width), int(height), fps, true
+	} else {
+		return 0, 0, 0, false
+	}
+}

--- a/example/ion-sfu-save-to-mkv/main.go
+++ b/example/ion-sfu-save-to-mkv/main.go
@@ -149,7 +149,11 @@ func main() {
 	flag.Parse()
 
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	rtc, err := sdk.NewRTC(connector)
+	if err != nil {
+		panic(err)
+	}
+
 	saver := newMkvSaver()
 	defer saver.Close()
 
@@ -186,7 +190,7 @@ func main() {
 	}
 
 	// client join a session
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	if err != nil {
 		log.Errorf("error: %v", err)

--- a/example/ion-sfu-save-to-webm/main.go
+++ b/example/ion-sfu-save-to-webm/main.go
@@ -65,7 +65,10 @@ func main() {
 	flag.Parse()
 
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	rtc, err := sdk.NewRTC(connector)
+	if err != nil {
+		panic(err)
+	}
 
 	// Create new Webm saver
 	var onceTrackAudio sync.Once
@@ -88,7 +91,7 @@ func main() {
 	}
 
 	// client join a session
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	if err != nil {
 		log.Errorf("error: %v", err)

--- a/example/ion-sfu-simple/main.go
+++ b/example/ion-sfu-simple/main.go
@@ -56,8 +56,14 @@ func main() {
 
 	log.Init(logLevel)
 
+	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	signaller, err := connector.Signal(rtc)
+	if err != nil {
+		log.Errorf("error: %v", err)
+		return
+	}
+	rtc.Start(signaller)
 
 	// user define receiving rtp
 	rtc.OnTrack = saveToDisk
@@ -70,7 +76,7 @@ func main() {
 		log.Errorf("err: %v", err)
 	}
 
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 	if err != nil {
 		log.Errorf("error: %v", err)
 		return

--- a/example/ion-sfu-simple/main.go
+++ b/example/ion-sfu-simple/main.go
@@ -56,14 +56,11 @@ func main() {
 
 	log.Init(logLevel)
 
-	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	signaller, err := connector.Signal(rtc)
+	rtc, err := sdk.NewRTC(connector)
 	if err != nil {
-		log.Errorf("error: %v", err)
-		return
+		panic(err)
 	}
-	rtc.Start(signaller)
 
 	// user define receiving rtp
 	rtc.OnTrack = saveToDisk

--- a/example/ion-sfu-track-to-rtp/main.go
+++ b/example/ion-sfu-track-to-rtp/main.go
@@ -26,7 +26,7 @@ type udpConn struct {
 }
 
 func trackToRTP(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
-	log.Infof("GOT TRACK", track, receiver)
+	log.Infof("GOT TRACK, track: %v, receiver: %v", track, receiver)
 
 	track_sdp := "track-" + track.ID() + ".sdp"
 
@@ -128,14 +128,19 @@ func main() {
 	flag.StringVar(&session, "session", "ion", "join session name")
 	flag.Parse()
 
+	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	rtc := sdk.NewRTC(connector)
+	signaller, err := connector.Signal(rtc)
+	if err != nil {
+		log.Fatal(err)
+	}
+	rtc.Start(signaller)
 
 	// subscribe rtp from sessoin
 	// comment this if you don't need save to file
 	rtc.OnTrack = trackToRTP
 
-	err := rtc.Join(session, sdk.RandomKey(4))
+	err = rtc.Join(session, sdk.RandomKey(4))
 
 	// publish file to session if needed
 	if err != nil {

--- a/example/ion-sfu-track-to-rtp/main.go
+++ b/example/ion-sfu-track-to-rtp/main.go
@@ -128,13 +128,11 @@ func main() {
 	flag.StringVar(&session, "session", "ion", "join session name")
 	flag.Parse()
 
-	rtc := sdk.NewRTC()
 	connector := sdk.NewConnector(addr)
-	signaller, err := connector.Signal(rtc)
+	rtc, err := sdk.NewRTC(connector)
 	if err != nil {
 		log.Fatal(err)
 	}
-	rtc.Start(signaller)
 
 	// subscribe rtp from sessoin
 	// comment this if you don't need save to file

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pion/ion-sdk-go
 go 1.16
 
 require (
+	github.com/at-wat/ebml-go v0.16.0
 	github.com/ebml-go/ebml v0.0.0-20160925193348-ca8851a10894 // indirect
 	github.com/ebml-go/webm v0.0.0-20160924163542-629e38feef2a
 	github.com/golang/protobuf v1.5.2

--- a/room.go
+++ b/room.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/metadata"
 	"io"
 	"sync"
 
@@ -572,6 +573,7 @@ func (c *Room) Name() string {
 func (c *Room) Connect() {
 	var err error
 	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.ctx = metadata.NewOutgoingContext(c.ctx, c.connector.Metadata)
 	c.roomServiceClient = room.NewRoomServiceClient(c.connector.grpcConn)
 	c.roomSignalClient = room.NewRoomSignalClient(c.connector.grpcConn)
 	c.roomSignalStream, err = c.roomSignalClient.Signal(c.ctx)

--- a/rtc.go
+++ b/rtc.go
@@ -154,8 +154,9 @@ type RTC struct {
 }
 
 func NewRTC(config ...RTCConfig) *RTC {
-
-	r := &RTC{}
+	r := &RTC{
+		notify: make(chan struct{}),
+	}
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 
 	if len(config) > 0 {

--- a/rtc.go
+++ b/rtc.go
@@ -153,7 +153,7 @@ type RTC struct {
 	sync.Mutex
 }
 
-func NewRTC(config ...RTCConfig) *RTC {
+func withConfig(config ...RTCConfig) *RTC {
 	r := &RTC{
 		notify: make(chan struct{}),
 	}
@@ -166,7 +166,22 @@ func NewRTC(config ...RTCConfig) *RTC {
 	return r
 }
 
-func (r *RTC) Start(signaller Signaller) {
+// NewRTC creates an RTC using the default GRPC signaller
+func NewRTC(connector *Connector, config ...RTCConfig) (*RTC, error) {
+	r := withConfig(config...)
+	signaller, err := connector.Signal(r)
+	r.start(signaller)
+	return r, err
+}
+
+// NewRTCWithSignaller creates an RTC with a specified signaller
+func NewRTCWithSignaller(signaller Signaller, config ...RTCConfig) *RTC {
+	r := withConfig(config...)
+	r.start(signaller)
+	return r
+}
+
+func (r *RTC) start(signaller Signaller) {
 	r.signaller = signaller
 
 	if !r.Connected() {

--- a/rtc.go
+++ b/rtc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"google.golang.org/grpc/metadata"
 	"io"
 	"os"
 	"path/filepath"
@@ -284,8 +285,8 @@ func (r *RTC) Publish(tracks ...webrtc.TrackLocal) ([]*webrtc.RTPSender, error) 
 		if rtpSender, err := r.pub.GetPeerConnection().AddTrack(t); err != nil {
 			log.Errorf("AddTrack error: %v", err)
 			return rtpSenders, err
-		}else{
-			rtpSenders=append(rtpSenders,rtpSender)
+		} else {
+			rtpSenders = append(rtpSenders, rtpSender)
 		}
 
 	}
@@ -303,7 +304,6 @@ func (r *RTC) UnPublish(senders ...*webrtc.RTPSender) error {
 	r.onNegotiationNeeded()
 	return nil
 }
-
 
 // CreateDataChannel create a custom datachannel
 func (r *RTC) CreateDataChannel(label string) (*webrtc.DataChannel, error) {
@@ -559,6 +559,7 @@ func (r *RTC) Connect() {
 	var err error
 
 	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.ctx = metadata.NewOutgoingContext(r.ctx, r.connector.Metadata)
 	r.client = rtc.NewRTCClient(r.connector.grpcConn)
 	r.stream, err = r.client.Signal(r.ctx)
 

--- a/rtc.go
+++ b/rtc.go
@@ -109,6 +109,11 @@ type RTCConfig struct {
 	WebRTC WebRTCTransportConfig `mapstructure:"webrtc"`
 }
 
+// Signaller sends and receives signalling messages with peers.
+// Signaller is derived from rtc.RTC_SignalClient, matching the
+// exported API of the GRPC Signal Service.
+// Signaller allows alternative signalling implementations
+// if the GRPC Signal Service does not fit your use case.
 type Signaller interface {
 	Send(request *rtc.Request) error
 	Recv() (*rtc.Reply, error)


### PR DESCRIPTION
The primary motivation around this PR is the conflict of the need for port 443 between SFU and TURN if behind restrictive enterprise firewalls. If on these networks, only TLS over 443 is allowed, then signalling the SFU on 443 and using TURN on 443 cannot co-exist. 

A minor refactor to rtc.go allows non-grpc methods of signalling. 

The 'Signaller' interface exactly matches the GRPC stream so does not break existing examples or server code.

```
type Signaller interface {
	Send(request *rtc.Request) error
	Recv() (*rtc.Reply, error)
	CloseSend() error
}
```

An example of how this can be implemented, in a system I'm building, we use a custom signalling server which clients communicate with, which in turn are propagated to the appropriate SFU server. 

The client side implementation is as follows:
```
func NewSFUSignaller(ctx context.Context, sid string) *signaller {
	s := &signaller{
		sid: sid,
		ch:  make(chan *rtc.Reply, 1),
	}
	s.ctx, s.cancel = context.WithCancel(ctx)
	return s
}

func (s *signaller) Send(request *rtc.Request) error {
	select {
	case <-s.ctx.Done():
		return errors.New("send closed")
	default:
	}

	b, err := proto.Marshal(request)
	if err != nil {
		return err
	}

	if err := s.sendSFUSignal(b); err != nil {
		return err
	}

	return nil
}

func (s *signaller) Recv() (*rtc.Reply, error) {
	select {
	case rep, ok := <-s.ch:
		if ok {
			return rep, nil
		}
		return nil, io.EOF
	case <-s.ctx.Done():
		return nil, errors.New("signaller closed")
	}
}
```
> NOTE: sendSFUSignal is an http POST to signalling server

You can see that the rtc protocol buffers are still used, and the interface is simply implemented.


